### PR TITLE
fix for nodejs v14 - https://github.com/brianc/node-postgres/pull/2171

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.16",
   "description": "Module PostgreSQL for work with Node-Red",
   "dependencies": {
-    "pg": "~7.4.1",
+    "pg": "^8.0.3",
     "node-postgres-named": "^2.4.1",
     "querystring": "^0.2.0"
   },


### PR DESCRIPTION
node-red-contrib-postgres-variable was pulling in an old version of the pg module which was broken on node v14